### PR TITLE
Make link options mobile friendly

### DIFF
--- a/pygmyui/templates/pygmy/index.html
+++ b/pygmyui/templates/pygmy/index.html
@@ -39,8 +39,8 @@
                 <div class="row horizontal-center">
                     <div class="col-xs-0">
                         <input type="checkbox" tabindex="3" name="secret_check" id="secret" onclick="readOnlyToggle('secretKey')">
+                        <label for="secret"> Secret </label>
                     </div>
-                    <div class="col-xs-1"><label for="secret"> Secret </label></div>
                     <div class="col-md-2">
                         <input class="form-control input-sm" name="secret_key" id="secretKey" placeholder="Secret key..." readonly>
                     </div>
@@ -49,8 +49,8 @@
                 <div class="row horizontal-center">
                     <div class="col-xs-0">
                         <input type="checkbox" tabindex="3" name="remember_check" id="expire" onclick="readOnlyToggle('expireTime')">
+                        <label for="expire"> Expire </label>
                     </div>
-                    <div class="col-xs-1"><label for="expire"> Expire </label></div>
                     <div class="col-md-2">
                         <input class="form-control input-sm" name="remember_time" id="expireTime" placeholder="Expire time in minutes." readonly>
                     </div>


### PR DESCRIPTION
Move labels of checkboxes into same \<div\> container, thereby \<input\> box doesn't overlap \<label\>.
Fix #11